### PR TITLE
Python3 compatibility and managed numerical error

### DIFF
--- a/llr.py
+++ b/llr.py
@@ -34,6 +34,9 @@ def llr_root(k11, k12, k21, k22):
     sign = cmp(float(k11) / (k11 + k12), float(row) / total)
     return math.copysign(math.sqrt(llr_2x2(k11, k12, k21, k22)), sign)
 
+def cmp(a, b):
+    return (a > b) - (a < b)
+
 def flatten(list_of_lists):
     '''Iterates through the elements in a list of lists'''
     for xl in list_of_lists:

--- a/llr.py
+++ b/llr.py
@@ -1,5 +1,7 @@
 from collections import Counter 
 import math
+from functools import reduce
+
 
 def llr(k):
     '''Computes an LLR score for a list of Count objects'''
@@ -32,10 +34,14 @@ def llr_root(k11, k12, k21, k22):
     row = k11 + k21
     total = (k11 + k12 + k21 + k22)
     sign = cmp(float(k11) / (k11 + k12), float(row) / total)
-    return math.copysign(math.sqrt(llr_2x2(k11, k12, k21, k22)), sign)
+    llr22 = llr_2x2(k11, k12, k21, k22)
+    if llr22 < 0: return 0.0
+    return math.copysign(math.sqrt(llr22), sign)
+
 
 def cmp(a, b):
-    return (a > b) - (a < b)
+    return int(a > b) - int(a < b)
+
 
 def flatten(list_of_lists):
     '''Iterates through the elements in a list of lists'''

--- a/tests.py
+++ b/tests.py
@@ -21,10 +21,10 @@ def test_rowSums():
     s1 = 'abcabcabcababa'
     s2 = 'abcabcdef'
     s3 = 'defghijkabc'
-    assert llr.rowSums([]) == Counter().values()
-    assert llr.rowSums([Counter(s1)]) == Counter(s1).values()
-    assert llr.rowSums([Counter(s1), Counter(s2)]) == Counter(s1 + s2).values()
-    assert llr.rowSums([Counter(s1), Counter(s2), Counter(s3)]) == Counter(s1 + s2 + s3).values()
+    assert tuple(llr.rowSums([])) == tuple(Counter().values())
+    assert tuple(llr.rowSums([Counter(s1)])) == tuple(Counter(s1).values())
+    assert tuple(llr.rowSums([Counter(s1), Counter(s2)])) == tuple(Counter(s1 + s2).values())
+    assert tuple(llr.rowSums([Counter(s1), Counter(s2), Counter(s3)])) == tuple(Counter(s1 + s2 + s3).values())
 
 def test_colSums():
     x = Counter('abcabcabcababa')


### PR DESCRIPTION
The code is compatible with Python 2 and 3.
Also there was a problem with negative value of llr causing error in llr_root:
```
>>> llr_2x2(1, 1109, 11449, 12697091)
-2.3283064365386963e-10
```